### PR TITLE
Add option to pass token file to filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ provided `oauth` configuration.
     (e.g. "All Files"). The client must have access to the application user's root
     folder (i.e., it cannot be downscoped to a subfolder)
 
-If only `root_id` is provided, the `root_path` is determined from API calls. If 
+If only `root_id` is provided, the `root_path` is determined from API calls. If
 only `root_path` is provided, the `root_id` is determined from API calls. If
 neither is provided, the application user's root folder is used.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "boxfs"
-version = "0.2.0"
+version = "0.2.1"
 description = "Implementation of fsspec for Box file storage"
 authors = ["Thomas Hunter <boxfs.tehunter@gmail.com>"]
 packages = [

--- a/src/boxfs/boxfs.py
+++ b/src/boxfs/boxfs.py
@@ -87,11 +87,11 @@ class BoxFileSystem(AbstractFileSystem):
             Path to Box root folder, must be relative to token root (e.g. "All Files").
             The client must have access to the application user's root folder (i.e., it
             cannot be downscoped to a subfolder)
-        
-        If only `root_id` is provided, the `root_path` is determined from API calls. If 
+
+        If only `root_id` is provided, the `root_path` is determined from API calls. If
         only `root_path` is provided, the `root_id` is determined from API calls. If
         neither is provided, the application user's root folder is used.
-            
+
         path_map : Mapping[path string -> object ID string], optional
             Mapping of paths to object ID strings, used to populate initial lookup cache
             for quick directory navigation
@@ -151,7 +151,7 @@ class BoxFileSystem(AbstractFileSystem):
                 root_id = self.root_id
 
         return root_id
-    
+
     def _get_root_path(self, root_id):
         folder = self.client.folder(root_id).get(fields=["name", "path_collection"])
         return self._construct_path(folder, relative=False)

--- a/src/boxfs/boxfs.py
+++ b/src/boxfs/boxfs.py
@@ -13,7 +13,7 @@ from typing import (
     Type
 )
 
-from boxsdk import BoxAPIException, Client, OAuth2
+from boxsdk import BoxAPIException, Client, OAuth2, JWTAuth
 from boxsdk.auth.oauth2 import TokenScope
 from boxsdk.object.item import Item
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
@@ -54,7 +54,7 @@ class BoxFileSystem(AbstractFileSystem):
     def __init__(
         self,
         client: Optional[Client] = None,
-        oauth: Optional[OAuth2] = None,
+        oauth: Optional[OAuth2 | _PathLike] = None,
         client_type: Type[Client] = Client,
         root_id: _ObjectId = None,
         root_path: _PathLike = None,
@@ -69,9 +69,9 @@ class BoxFileSystem(AbstractFileSystem):
 
         Parameters
         ----------
-        oauth : OAuth2, optional
-            Box app OAuth2 configuration, e.g. loaded from `JWTAuth.from_settings_file`,
-            by default None
+        oauth : OAuth2 or str, optional
+            Box app OAuth2 configuration or path to configuration file, which is
+            passed to `JWTAuth.from_settings_file`, by default None
         client : Client, optional
             Instantiated boxsdk client
         client_type : Type[Client]
@@ -109,6 +109,8 @@ class BoxFileSystem(AbstractFileSystem):
             path_map = {}
         self.path_map = path_map
         if client is None:
+            if isinstance(oauth, str):
+                oauth = JWTAuth.from_settings_file(oauth)
             self.connect(oauth, client_type)
         else:
             self.client = client.clone()

--- a/tests/_utilities.py
+++ b/tests/_utilities.py
@@ -23,6 +23,7 @@ USER_ROOT = {
     "name": "All Files",
 }
 
+
 def ItemJSON(
     name,
     id,
@@ -223,7 +224,7 @@ class BoxFileSystemMocker:
                 yield
         else:
             yield
-    
+
     @pytest.fixture(scope="class")
     def mock_item_delete(test, do_mock, box_error):
         def file_delete(self, *args, **kwargs):
@@ -266,7 +267,6 @@ class BoxFileSystemMocker:
         else:
             yield
 
-
     @pytest.fixture(scope="class")
     def mock_upload(test, do_mock, client, fs, scopes):
         created_files = set()
@@ -298,7 +298,7 @@ class BoxFileSystemMocker:
             data_contents = data.read()
 
             file = _build_file(self, file_id, data_contents, **kwargs)
-            
+
             # Update stored file response object
             test.file_items[file_id]._response_object = file._response_object
             test.file_items[file_id].__dict__.update(file._response_object)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ def client(do_mock, request, logger):
 
         yield client
 
+
 @pytest.fixture(scope="module")
 def client_type():
     import boxsdk
@@ -92,9 +93,11 @@ BOX_CODES = {
     }
 }
 
+
 @pytest.fixture(scope="session")
 def box_error():
     import boxsdk
+
     def _error(code, **kwargs):
         error_details = BOX_CODES[code]
         return boxsdk.BoxAPIException(
@@ -117,7 +120,6 @@ def box_error():
             network_response=None,
         )
     yield _error
-
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,11 +31,19 @@ def client(do_mock, request, logger):
     else:
         logger.info("running real client")
         api_config = request.config.getoption("api_config")
-        config = JWTAuth.from_settings_file(api_config)
+        if api_config is not None:
+            config = JWTAuth.from_settings_file(api_config)
 
-        client = boxsdk.LoggingClient(config)
+            client = boxsdk.LoggingClient(config)
+        else:
+            client = None
 
         yield client
+
+@pytest.fixture(scope="module")
+def client_type():
+    import boxsdk
+    return boxsdk.LoggingClient
 
 
 @pytest.fixture(

--- a/tests/test_boxfs.py
+++ b/tests/test_boxfs.py
@@ -41,8 +41,10 @@ def write_expectation(scopes, request):
 
 class TestBoxFileSystem(BoxFileSystemMocker):
     @pytest.fixture(scope="class")
-    def fs(self, client, root_id, root_path, mock_folder_get, scopes):
-        fs = fsspec.filesystem("box", client=client.clone(), root_id=root_id)
+    def fs(self, client, client_type, root_id, root_path, mock_folder_get, scopes):
+        if client is not None:
+            client = client.clone()
+        fs = fsspec.filesystem("box", client=client, root_id=root_id, client_type=client_type, cache_paths=False)
 
         if scopes:
             try:

--- a/tests/test_boxfs.py
+++ b/tests/test_boxfs.py
@@ -44,7 +44,13 @@ class TestBoxFileSystem(BoxFileSystemMocker):
     def fs(self, client, client_type, root_id, root_path, mock_folder_get, scopes):
         if client is not None:
             client = client.clone()
-        fs = fsspec.filesystem("box", client=client, root_id=root_id, client_type=client_type, cache_paths=False)
+        fs = fsspec.filesystem(
+            "box",
+            client=client,
+            root_id=root_id,
+            client_type=client_type,
+            cache_paths=False
+        )
 
         if scopes:
             try:
@@ -64,7 +70,6 @@ class TestBoxFileSystem(BoxFileSystemMocker):
                 f.write(text.encode())
             return text
         yield _write
-
 
     @pytest.mark.usefixtures(
         "mock_folder_get_items",
@@ -92,8 +97,8 @@ class TestBoxFileSystem(BoxFileSystemMocker):
         with write_expectation:
             # Go twice to test upload + update
             for i in range(2):
-                # Use different ranges for each call to test that the file size updates
-                # correctly
+                # Use different ranges for each call to test that the file size
+                # updates correctly
                 _min, _max = i * 1e5, 10**(5 * (i+1)) - 1
                 a, b = random.randint(_min, _max), random.randint(_min, _max)
                 text = f"{a} {b} DONE"
@@ -101,7 +106,7 @@ class TestBoxFileSystem(BoxFileSystemMocker):
                     f.write(text.encode())
                 file_contents: bytes = fs.cat(path)
                 assert file_contents.decode() == text
-    
+
     @pytest.mark.usefixtures(
         "mock_folder_get_items",
         "mock_item_delete",
@@ -115,7 +120,6 @@ class TestBoxFileSystem(BoxFileSystemMocker):
             fs.rm(path)
 
             assert not fs.exists(path)
-
 
     @pytest.mark.usefixtures(
         "mock_file_content",

--- a/tests/upath/test_upath.py
+++ b/tests/upath/test_upath.py
@@ -23,6 +23,7 @@ class TestBoxUPath(BoxFileSystemMocker):
     def test_path(
         self,
         client,
+        client_type,
         root_id,
         root_path,
         scopes,
@@ -31,6 +32,9 @@ class TestBoxUPath(BoxFileSystemMocker):
     ):
         if root_id is None:
             root_id = "0"
+        if client is None:
+            import fsspec
+            client = fsspec.filesystem("box", client_type=client_type).client
         client.folder(root_id).create_subfolder("Test UPath Folder")
         yield upath.UPath(
             "box:///Test UPath Folder",

--- a/tests/upath/test_upath.py
+++ b/tests/upath/test_upath.py
@@ -6,9 +6,11 @@ import upath
 from .._utilities import BoxFileSystemMocker
 import boxfs  # noqa: F401
 
+
 @pytest.mark.mock_only
 def test_box_protocol_registered():
     assert "box" in upath.registry._registry.known_implementations
+
 
 @pytest.fixture(
     scope="class",
@@ -43,7 +45,7 @@ class TestBoxUPath(BoxFileSystemMocker):
             root_path=root_path,
             scopes=scopes
         )
-    
+
     @pytest.mark.usefixtures(
         "mock_folder_get_items",
         "mock_folder_get",
@@ -60,8 +62,8 @@ class TestBoxUPath(BoxFileSystemMocker):
 
         with file_path.open("wt", encoding="utf-8") as f:
             f.write(text)
-        
+
         with file_path.open("rt", encoding="utf-8") as f:
             read_text = f.read()
-        
+
         assert read_text == text


### PR DESCRIPTION
Allows the `oauth` parameter to accept a str, which will be interpreted as a path to the JSON app settings file. Useful for setting the default [configuration](https://filesystem-spec.readthedocs.io/en/latest/features.html#configuration) via user files or environment variables.

$HOME/.config/fsspec/box_config.json: `{"box": {"oauth": "/path/to/app_config.json"}}`